### PR TITLE
ファイルとディレクトリを一括で扱えるモデルクラスを作成

### DIFF
--- a/WPFFiler.sln
+++ b/WPFFiler.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFFiler", "WPFFiler\WPFFiler.csproj", "{79C4A3F7-8C7F-4CEB-B80D-0340379DDF95}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPFFilerTests", "WPFFilerTests\WPFFilerTests.csproj", "{92AAEA6E-A66F-421B-BA69-8A5EAD40B306}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{79C4A3F7-8C7F-4CEB-B80D-0340379DDF95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79C4A3F7-8C7F-4CEB-B80D-0340379DDF95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79C4A3F7-8C7F-4CEB-B80D-0340379DDF95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92AAEA6E-A66F-421B-BA69-8A5EAD40B306}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92AAEA6E-A66F-421B-BA69-8A5EAD40B306}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92AAEA6E-A66F-421B-BA69-8A5EAD40B306}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92AAEA6E-A66F-421B-BA69-8A5EAD40B306}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WPFFiler/WPFFiler.csproj
+++ b/WPFFiler/WPFFiler.csproj
@@ -79,6 +79,7 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="models\ExFile.cs" />
     <Compile Include="models\FileList.cs" />
     <Compile Include="viewModels\MainWindowViewModel.cs" />
     <Compile Include="views\MainWindow.xaml.cs">

--- a/WPFFiler/models/ExFile.cs
+++ b/WPFFiler/models/ExFile.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPFFiler.models {
+    public class ExFile {
+
+        private FileSystemInfo content;
+        public FileSystemInfo Content {
+            get => content;
+            set {
+                content = value;
+            }
+        }
+
+        private string currentPath;
+        public string CurrentPath {
+            get => currentPath;
+            set {
+                currentPath = value;
+            }
+        }
+
+        public ExFile(string path) {
+            FileSystemInfo f;
+            CurrentPath = path;
+            if (!Exists(path)) {
+                return;
+            }
+
+            Content = (Directory.Exists(path)) ? (FileSystemInfo)new DirectoryInfo(path) : (FileSystemInfo)new FileInfo(path);
+        }
+
+        public Boolean Exists(string path) {
+            return (File.Exists(path) || Directory.Exists(path));
+        }
+
+    }
+}

--- a/WPFFiler/models/ExFile.cs
+++ b/WPFFiler/models/ExFile.cs
@@ -24,6 +24,12 @@ namespace WPFFiler.models {
             }
         }
 
+        /// <summary>
+        /// ExFileインスタンスを生成します。
+        /// 存在しないパスを指定した場合、対象がファイルかディレクトリか確定できないため、Content プロパティに値が入力されません。
+        /// Content を使用する場合には、createFile() or createDirectory() を使用して実体を作成してから使用します。
+        /// </summary>
+        /// <param name="path"></param>
         public ExFile(string path) {
             CurrentPath = path;
             if (!Exists) {
@@ -39,6 +45,26 @@ namespace WPFFiler.models {
         /// 対象がディレクトリであるかを取得します。対象がファイルであるか、存在しない場合は false を返します。
         /// </summary>
         public Boolean IsDirectory { get => (Directory.Exists(CurrentPath)); }
+
+        /// <summary>
+        /// CurrentPath の値を使用してファイルを新規作成します。
+        /// このメソッドを呼び出すと、Content に FileInfo がセットされます。
+        /// </summary>
+        public void createFile() {
+            var f = new FileInfo(CurrentPath);
+            File.Create(f.FullName).Close();
+            Content = f;
+        }
+
+        /// <summary>
+        /// CurrentPath の値を使用してディレクトリを作成します。
+        /// このメソッドを呼び出すと、Content に DirectoryInfo がセットされます。
+        /// </summary>
+        public void createDirectory() {
+            var d = new DirectoryInfo(CurrentPath);
+            Directory.CreateDirectory(CurrentPath);
+            Content = d;
+        }
 
     }
 }

--- a/WPFFiler/models/ExFile.cs
+++ b/WPFFiler/models/ExFile.cs
@@ -35,5 +35,10 @@ namespace WPFFiler.models {
 
         public Boolean Exists { get => (File.Exists(CurrentPath) || Directory.Exists(CurrentPath)); }
 
+        /// <summary>
+        /// 対象がディレクトリであるかを取得します。対象がファイルであるか、存在しない場合は false を返します。
+        /// </summary>
+        public Boolean IsDirectory { get => (Directory.Exists(CurrentPath)); }
+
     }
 }

--- a/WPFFiler/models/ExFile.cs
+++ b/WPFFiler/models/ExFile.cs
@@ -25,18 +25,15 @@ namespace WPFFiler.models {
         }
 
         public ExFile(string path) {
-            FileSystemInfo f;
             CurrentPath = path;
-            if (!Exists(path)) {
+            if (!Exists) {
                 return;
             }
 
             Content = (Directory.Exists(path)) ? (FileSystemInfo)new DirectoryInfo(path) : (FileSystemInfo)new FileInfo(path);
         }
 
-        public Boolean Exists(string path) {
-            return (File.Exists(path) || Directory.Exists(path));
-        }
+        public Boolean Exists { get => (File.Exists(CurrentPath) || Directory.Exists(CurrentPath)); }
 
     }
 }

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -10,8 +10,8 @@ using System.Threading.Tasks;
 namespace WPFFiler.models {
     class FileList : BindableBase{
 
-        private ObservableCollection<FileSystemInfo> files = new ObservableCollection<FileSystemInfo>();
-        public ObservableCollection<FileSystemInfo> Files {
+        private ObservableCollection<ExFile> files = new ObservableCollection<ExFile>();
+        public ObservableCollection<ExFile> Files {
             private get => files;
             set => SetProperty(ref files, value);
         }
@@ -28,14 +28,14 @@ namespace WPFFiler.models {
             string[] directoryPaths = Directory.GetDirectories(currentDirectoryPath);
 
             Files.Clear();
-            List<FileSystemInfo> tempFiles = new List<FileSystemInfo>();
+            List<ExFile> tempFiles = new List<ExFile>();
             foreach(string p in paths) {
-                tempFiles.Add(new FileInfo(p));
+                tempFiles.Add(new ExFile(p));
             }
 
-            List<FileSystemInfo> tempDirectories = new List<FileSystemInfo>();
+            List<ExFile> tempDirectories = new List<ExFile>();
             foreach(string dp in directoryPaths) {
-                tempDirectories.Add(new DirectoryInfo(dp));
+                tempDirectories.Add(new ExFile(dp));
             }
 
             Files.AddRange(tempFiles);

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -69,7 +69,7 @@
                 <GridView>
                     <GridView.Columns>
                         <GridViewColumn Header="name"
-                                        DisplayMemberBinding="{Binding Name}"
+                                        DisplayMemberBinding="{Binding Content.Name}"
                                         />
                     </GridView.Columns>
                 </GridView>

--- a/WPFFilerTests/Properties/AssemblyInfo.cs
+++ b/WPFFilerTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットを使用して制御されます。 
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("WPFFilerTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("WPFFilerTests")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから
+// 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、 
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
+[assembly: Guid("92aaea6e-a66f-421b-ba69-8a5ead40b306")]
+
+// アセンブリのバージョン情報は次の 4 つの値で構成されています:
+//
+//      メジャー バージョン
+//      マイナー バージョン
+//      ビルド番号
+//      Revision
+//
+// すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
+// 既定値にすることができます:
+//[アセンブリ: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WPFFilerTests/WPFFilerTests.csproj
+++ b/WPFFilerTests/WPFFilerTests.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{92AAEA6E-A66F-421B-BA69-8A5EAD40B306}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WPFFilerTests</RootNamespace>
+    <AssemblyName>WPFFilerTests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="models\ExFileTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WPFFiler\WPFFiler.csproj">
+      <Project>{79C4A3F7-8C7F-4CEB-B80D-0340379DDF95}</Project>
+      <Name>WPFFiler</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/WPFFilerTests/models/ExFileTests.cs
+++ b/WPFFilerTests/models/ExFileTests.cs
@@ -13,6 +13,7 @@ namespace WPFFiler.models.Tests {
 
         private readonly string emptyTextFileName0 = "emptyFile0.txt";
         private readonly string emptyTextFileName1 = "emptyFile1.txt";
+        private readonly string emptyDirectoryName = "emptyDirectory";
 
         /// <summary>
         /// 空白ファイル emptyFile0.txt,emptyFile1.txt の作成
@@ -47,6 +48,21 @@ namespace WPFFiler.models.Tests {
         public void ExFileTest() {
             FileInfo f0 = new FileInfo(emptyTextFileName0);
             ExFile f = new ExFile(f0.FullName);
+        }
+
+        [TestMethod()]
+        public void ExistsTest() {
+            // initialize で生成したファイルが存在するか
+            ExFile f = new ExFile(emptyTextFileName0);
+            Assert.IsTrue(f.Exists);
+
+            // 存在しないファイルを指定した際、false が返って来るか
+            ExFile notExistFile = new ExFile("notExistsFile");
+            Assert.IsFalse(notExistFile.Exists);
+
+            // 指定したパスがディレクトリであっても、存在すると判定されるか
+            ExFile d = new ExFile(emptyDirectoryName);
+            Assert.IsTrue(d.Exists);
         }
     }
 }

--- a/WPFFilerTests/models/ExFileTests.cs
+++ b/WPFFilerTests/models/ExFileTests.cs
@@ -64,5 +64,17 @@ namespace WPFFiler.models.Tests {
             ExFile d = new ExFile(emptyDirectoryName);
             Assert.IsTrue(d.Exists);
         }
+
+        [TestMethod()]
+        public void IsDirectoryTest() {
+            // 存在するディレクトリ
+            Assert.IsTrue(new ExFile(emptyDirectoryName).IsDirectory);
+
+            // 存在するファイル
+            Assert.IsFalse(new ExFile(emptyTextFileName0).IsDirectory);
+
+            // 存在しないパス
+            Assert.IsFalse(new ExFile("testFileName").IsDirectory);
+        }
     }
 }

--- a/WPFFilerTests/models/ExFileTests.cs
+++ b/WPFFilerTests/models/ExFileTests.cs
@@ -76,5 +76,33 @@ namespace WPFFiler.models.Tests {
             // 存在しないパス
             Assert.IsFalse(new ExFile("testFileName").IsDirectory);
         }
+
+        [TestMethod()]
+        public void createFileTest() {
+            File.Delete("notExistFile");
+
+            ExFile f = new ExFile("notExistFile");
+            Assert.IsFalse(f.Exists);
+            Assert.IsNull(f.Content);
+
+            f.createFile();
+            Assert.IsTrue(f.Exists);
+            Assert.IsFalse(f.IsDirectory);
+            Assert.IsNotNull(f.Content);
+        }
+
+        [TestMethod()]
+        public void createDirectoryTest() {
+            Directory.Delete("notExistDirectory");
+
+            ExFile d = new ExFile("notExistDirectory");
+            Assert.IsFalse(d.Exists);
+            Assert.IsNull(d.Content);
+
+            d.createDirectory();
+            Assert.IsTrue(d.Exists);
+            Assert.IsTrue(d.IsDirectory);
+            Assert.IsNotNull(d.Content);
+        }
     }
 }

--- a/WPFFilerTests/models/ExFileTests.cs
+++ b/WPFFilerTests/models/ExFileTests.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WPFFiler.models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace WPFFiler.models.Tests {
+    [TestClass()]
+    public class ExFileTests {
+
+        private readonly string emptyTextFileName0 = "emptyFile0.txt";
+        private readonly string emptyTextFileName1 = "emptyFile1.txt";
+
+        /// <summary>
+        /// 空白ファイル emptyFile0.txt,emptyFile1.txt の作成
+        /// </summary>
+        [TestInitialize]
+        public void TestInitialize() {
+            File.WriteAllLines("emptyFile0.txt", new string[0]);
+            File.WriteAllLines("emptyFile1.txt", new string[0]);
+            Directory.CreateDirectory("emptyDirectory");
+        }
+
+        [TestCleanup]
+        public void TestCleanup() {
+            var f0 = new FileInfo("emptyFile0.txt");
+            var f1 = new FileInfo("emptyFile1.tx");
+            var d0 = new DirectoryInfo("emptyDirectory");
+
+            if (File.Exists(f0.FullName)) {
+                f0.Delete();
+            }
+
+            if (File.Exists(f1.FullName)) {
+                f1.Delete();
+            }
+
+            if (Directory.Exists(d0.FullName)) {
+                d0.Delete();
+            }
+        }
+
+        [TestMethod()]
+        public void ExFileTest() {
+            FileInfo f0 = new FileInfo(emptyTextFileName0);
+            ExFile f = new ExFile(f0.FullName);
+        }
+    }
+}

--- a/WPFFilerTests/packages.config
+++ b/WPFFilerTests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
- クラス追加 / ファイル、ディレクトリを表すモデルクラスを追加
- 機能変更 / Exists() を引数を取るメソッドからプロパティへ変更
- テストプロジェクト、ExFileのテストクラスを追加
- テスト追加 / ExFile.Exists のテストを追加
- 機能追加 / ExFile がディレクトリかどうかを確認するプロパティを追加
- 機能変更 / FileList 内で扱う ListItem の型を FileSystemInfo から ExFile に変更
- 機能追加 / ExFile に ファイル、ディレクトリを作成するメソッドを追加

close #3
