### PR TITLE
キーボードから呼び出すコマンドを集約するクラスを作成

### DIFF
--- a/WPFFiler/WPFFiler.csproj
+++ b/WPFFiler/WPFFiler.csproj
@@ -81,6 +81,7 @@
     </Compile>
     <Compile Include="models\ExFile.cs" />
     <Compile Include="models\FileList.cs" />
+    <Compile Include="models\FileListControlCommands.cs" />
     <Compile Include="viewModels\MainWindowViewModel.cs" />
     <Compile Include="views\MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -38,6 +38,8 @@ namespace WPFFiler.models {
         }
 
         public void reload() {
+            SelectedIndex = 0;
+
             string[] paths = Directory.GetFiles(CurrentDirectoryPath);
             string[] directoryPaths = Directory.GetDirectories(CurrentDirectoryPath);
 

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -8,7 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace WPFFiler.models {
-    class FileList : BindableBase{
+    public class FileList : BindableBase{
 
         private ObservableCollection<ExFile> files = new ObservableCollection<ExFile>();
         public ObservableCollection<ExFile> Files {

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -12,7 +12,7 @@ namespace WPFFiler.models {
 
         private ObservableCollection<ExFile> files = new ObservableCollection<ExFile>();
         public ObservableCollection<ExFile> Files {
-            private get => files;
+            get => files;
             set => SetProperty(ref files, value);
         }
 

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -22,6 +22,16 @@ namespace WPFFiler.models {
             set => SetProperty(ref currentDirectoryPath, value);
         }
 
+        private int selectedIndex = 0;
+        public int SelectedIndex {
+            get => selectedIndex;
+            set {
+                if(value >= 0 && value < Files.Count) {
+                    SetProperty(ref selectedIndex, value);
+                }
+            }
+        }
+
         public FileList(string baseDirectoryPath) {
             currentDirectoryPath = baseDirectoryPath;
             reload();

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -19,7 +19,10 @@ namespace WPFFiler.models {
         private string currentDirectoryPath = "";
         public string CurrentDirectoryPath {
             get => currentDirectoryPath;
-            set => SetProperty(ref currentDirectoryPath, value);
+            set {
+                SetProperty(ref currentDirectoryPath, value);
+                reload();
+            }
         }
 
         private int selectedIndex = 0;

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Prism.Commands;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,5 +13,25 @@ namespace WPFFiler.models {
         public FileListControlCommands(FileList main) {
             mainFileList = main;
         }
+
+        private DelegateCommand downCursorCommand;
+        public DelegateCommand DownCursorCommand {
+            get => downCursorCommand ?? (downCursorCommand = new DelegateCommand(
+                () => {
+                    mainFileList.SelectedIndex++;
+                }
+            ));
+        }
+
+        private DelegateCommand upCursorCommand;
+        public DelegateCommand UpCursorCommand {
+            get => upCursorCommand ?? (upCursorCommand = new DelegateCommand(
+                () => {
+                    mainFileList.SelectedIndex--;
+                }
+            ));
+        }
+
+
     }
 }

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -29,7 +29,13 @@ namespace WPFFiler.models {
         public DelegateCommand MoveCursorToHeadCommand {
             get => moveCursorToHeadCommand ?? (moveCursorToHeadCommand = new DelegateCommand(
                 () => {
-                    mainFileList.SelectedIndex = 0;
+                    if(repeatCount == 0) {
+                        mainFileList.SelectedIndex = 0;
+                    }
+                    else {
+                        mainFileList.SelectedIndex = repeatCount;
+                        repeatCount = 0;
+                    }
                 }
             ));
         }

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -38,7 +38,12 @@ namespace WPFFiler.models {
         public DelegateCommand DownCursorCommand {
             get => downCursorCommand ?? (downCursorCommand = new DelegateCommand(
                 () => {
-                    mainFileList.SelectedIndex++;
+                    if(repeatCount == 0) {
+                        mainFileList.SelectedIndex++;
+                    }
+                    else {
+                        repeatCommand(() => mainFileList.SelectedIndex++);
+                    }
                 }
             ));
         }
@@ -47,7 +52,12 @@ namespace WPFFiler.models {
         public DelegateCommand UpCursorCommand {
             get => upCursorCommand ?? (upCursorCommand = new DelegateCommand(
                 () => {
-                    mainFileList.SelectedIndex--;
+                    if(repeatCount == 0) {
+                        mainFileList.SelectedIndex--;
+                    }
+                    else {
+                        repeatCommand(() => mainFileList.SelectedIndex--);
+                    }
                 }
             ));
         }
@@ -94,6 +104,18 @@ namespace WPFFiler.models {
 
                 }
             ));
+        }
+
+        /// <summary>
+        /// repeatCount の回数だけ action を実行し、実行後に repeatCount を 0 にセットします
+        /// </summary>
+        /// <param name="action"></param>
+        private void repeatCommand(Action action) {
+            for(int i = 0; i < repeatCount; i++) {
+                action();
+            }
+
+            repeatCount = 0;
         }
 
     }

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -4,10 +4,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace WPFFiler.models {
     public class FileListControlCommands {
 
+        private int repeatCount = 0;
         private FileList mainFileList;
 
         public FileListControlCommands(FileList main) {
@@ -68,5 +70,31 @@ namespace WPFFiler.models {
                 }
             ));
         }
+
+        private DelegateCommand<object> setRepeatCountCommand;
+        public DelegateCommand<object> SetRepeatCountCommand {
+            get => setRepeatCountCommand ?? (setRepeatCountCommand = new DelegateCommand<object>(
+                (object param) => {
+
+                    string numberString = param.ToString().Substring(1);
+                    // パラメーターに入ってくる文字列は "d0" から "d9" までの10種類。
+                    // dxの数字部分が、数字キーと対応している。
+
+                    if(repeatCount == 0) {
+                        repeatCount = int.Parse(numberString);
+                    }
+                    else {
+                        string stringNumbers = repeatCount.ToString() + numberString;
+                        repeatCount = int.Parse(stringNumbers);
+                    }
+
+                    if(repeatCount > 100) {
+                        repeatCount = 100;
+                    }
+
+                }
+            ));
+        }
+
     }
 }

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -77,6 +77,17 @@ namespace WPFFiler.models {
             ));
         }
 
+        private DelegateCommand openDirectoryCommand;
+        public DelegateCommand OpenDirectoryCommand {
+            get => openDirectoryCommand ?? (openDirectoryCommand = new DelegateCommand(
+                () => {
+                    mainFileList.CurrentDirectoryPath = mainFileList.Files[mainFileList.SelectedIndex].Content.FullName;
+                },
+                () => mainFileList.Files[mainFileList.SelectedIndex].IsDirectory
+            ));
+        }
+
+
         private DelegateCommand<object> focusCommand;
         public DelegateCommand<object> FocusCommand { 
             get => focusCommand ?? (focusCommand = new DelegateCommand<object>(

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPFFiler.models {
+    public class FileListControlCommands {
+
+        private FileList mainFileList;
+
+        public FileListControlCommands(FileList main) {
+            mainFileList = main;
+        }
+    }
+}

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -58,5 +58,15 @@ namespace WPFFiler.models {
                 }
             ));
         }
+
+        private DelegateCommand<object> focusCommand;
+        public DelegateCommand<object> FocusCommand { 
+            get => focusCommand ?? (focusCommand = new DelegateCommand<object>(
+                (object param) => {
+                    var view = (System.Windows.Controls.Control)param;
+                    view.Focus();
+                }
+            ));
+        }
     }
 }

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Input;
+using System.IO;
 
 namespace WPFFiler.models {
     public class FileListControlCommands {
@@ -87,6 +88,25 @@ namespace WPFFiler.models {
             ));
         }
 
+        private DelegateCommand moveToParentDirectory;
+        public DelegateCommand MoveToParentDirectory {
+            get => moveToParentDirectory ?? (moveToParentDirectory = new DelegateCommand(
+                () => {
+                    if(repeatCount == 0) {
+                        mainFileList.CurrentDirectoryPath = new DirectoryInfo(mainFileList.CurrentDirectoryPath).Parent.FullName;
+                    }
+                    else {
+                        repeatCommand(() => {
+                            var parentDirectory = new DirectoryInfo(mainFileList.CurrentDirectoryPath).Parent;
+                            if(parentDirectory != null) {
+                                mainFileList.CurrentDirectoryPath = parentDirectory.FullName;
+                            }
+                        });
+                    }
+                },
+                () => new DirectoryInfo(mainFileList.CurrentDirectoryPath).Parent != null
+            ));
+        }
 
         private DelegateCommand<object> focusCommand;
         public DelegateCommand<object> FocusCommand { 

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -14,6 +14,24 @@ namespace WPFFiler.models {
             mainFileList = main;
         }
 
+        private DelegateCommand moveCursorToEndCommand;
+        public DelegateCommand MoveCursorToEndCommand {
+            get => moveCursorToEndCommand ?? (moveCursorToEndCommand = new DelegateCommand(
+                () => {
+                    mainFileList.SelectedIndex = mainFileList.Files.Count - 1;
+                }
+            ));
+        }
+
+        private DelegateCommand moveCursorToHeadCommand;
+        public DelegateCommand MoveCursorToHeadCommand {
+            get => moveCursorToHeadCommand ?? (moveCursorToHeadCommand = new DelegateCommand(
+                () => {
+                    mainFileList.SelectedIndex = 0;
+                }
+            ));
+        }
+
         private DelegateCommand downCursorCommand;
         public DelegateCommand DownCursorCommand {
             get => downCursorCommand ?? (downCursorCommand = new DelegateCommand(

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -32,6 +32,13 @@ namespace WPFFiler.models {
             ));
         }
 
-
+        private DelegateCommand reloadCommand;
+        public DelegateCommand ReloadCommand {
+            get => reloadCommand ?? (reloadCommand = new DelegateCommand(
+                () => {
+                    mainFileList.reload();
+                }
+            ));
+        }
     }
 }

--- a/WPFFiler/viewModels/MainWindowViewModel.cs
+++ b/WPFFiler/viewModels/MainWindowViewModel.cs
@@ -14,5 +14,15 @@ namespace WPFFiler.viewModels {
             get;
             private set;
         } = new FileList(@"C:\");
+
+        public FileListControlCommands FileListControlCommands {
+            get;
+            private set;
+        }
+
+        public MainWindowViewModel() {
+            FileListControlCommands = new FileListControlCommands(FileList);
+        }
+
     }
 }

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -34,6 +34,7 @@
                 <KeyBinding Key="G" Command="{Binding FileListControlCommands.MoveCursorToHeadCommand}" />
                 <KeyBinding Key="G" Modifiers="Shift" Command="{Binding FileListControlCommands.MoveCursorToEndCommand}" />
                 <KeyBinding Gesture="CTRL+R" Command="{Binding FileListControlCommands.ReloadCommand}" />
+                <KeyBinding Key="O" Command="{Binding FileListControlCommands.OpenDirectoryCommand}" />
 
                 <!-- 数字キーを受け取るコマンド -->
                 <KeyBinding Key="D0" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -34,6 +34,30 @@
                 <KeyBinding Key="G" Command="{Binding FileListControlCommands.MoveCursorToHeadCommand}" />
                 <KeyBinding Key="G" Modifiers="Shift" Command="{Binding FileListControlCommands.MoveCursorToEndCommand}" />
                 <KeyBinding Gesture="CTRL+R" Command="{Binding FileListControlCommands.ReloadCommand}" />
+
+                <!-- 数字キーを受け取るコマンド -->
+                <KeyBinding Key="D0" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D1" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D2" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D3" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D4" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+
+                <KeyBinding Key="D5" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D6" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D7" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D8" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                <KeyBinding Key="D9" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"
+                            CommandParameter="{Binding RelativeSource={RelativeSource Self},Path=Key}"/>
+                
             </Grid.InputBindings>
 
             <ListView ItemsSource="{Binding FileList.Files}"

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -21,6 +21,7 @@
             <Grid.InputBindings>
                 <KeyBinding Key="J" Command="{Binding FileListControlCommands.DownCursorCommand}" />
                 <KeyBinding Key="K" Command="{Binding FileListControlCommands.UpCursorCommand}" />
+                <KeyBinding Gesture="CTRL+R" Command="{Binding FileListControlCommands.ReloadCommand}" />
             </Grid.InputBindings>
 
             <ListView ItemsSource="{Binding FileList.Files}"

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -21,6 +21,8 @@
             <Grid.InputBindings>
                 <KeyBinding Key="J" Command="{Binding FileListControlCommands.DownCursorCommand}" />
                 <KeyBinding Key="K" Command="{Binding FileListControlCommands.UpCursorCommand}" />
+                <KeyBinding Key="G" Command="{Binding FileListControlCommands.MoveCursorToHeadCommand}" />
+                <KeyBinding Key="G" Modifiers="Shift" Command="{Binding FileListControlCommands.MoveCursorToEndCommand}" />
                 <KeyBinding Gesture="CTRL+R" Command="{Binding FileListControlCommands.ReloadCommand}" />
             </Grid.InputBindings>
 

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -17,9 +17,15 @@
                  Text="{Binding FileList.CurrentDirectoryPath}"
                  />
 
-        <Grid>
+        <Grid Focusable="True">
+            <Grid.InputBindings>
+                <KeyBinding Key="J" Command="{Binding FileListControlCommands.DownCursorCommand}" />
+                <KeyBinding Key="K" Command="{Binding FileListControlCommands.UpCursorCommand}" />
+            </Grid.InputBindings>
 
-            <ListView ItemsSource="{Binding FileList.Files}">
+            <ListView ItemsSource="{Binding FileList.Files}"
+                      SelectedIndex="{Binding FileList.SelectedIndex}"
+                      >
 
                 <ListView.ItemContainerStyle>
                     <Style TargetType="ListViewItem">

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -11,6 +11,16 @@
     <Window.DataContext>
         <dc:MainWindowViewModel/>
     </Window.DataContext>
+
+    <Window.InputBindings>
+
+        <KeyBinding Key="Esc" Command="{Binding FileListControlCommands.FocusCommand}"
+                    CommandParameter="{Binding ElementName=FileListView}"
+                    />
+        <KeyBinding Key="OemOpenBrackets" Modifiers="Ctrl" Command="{Binding FileListControlCommands.FocusCommand}"
+                    CommandParameter="{Binding ElementName=FileListView}"/>
+    </Window.InputBindings>
+    
     <StackPanel>
         
         <TextBox x:Name="urlBar"
@@ -28,6 +38,7 @@
 
             <ListView ItemsSource="{Binding FileList.Files}"
                       SelectedIndex="{Binding FileList.SelectedIndex}"
+                      x:Name="FileListView"
                       >
 
                 <ListView.ItemContainerStyle>

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -35,6 +35,7 @@
                 <KeyBinding Key="G" Modifiers="Shift" Command="{Binding FileListControlCommands.MoveCursorToEndCommand}" />
                 <KeyBinding Gesture="CTRL+R" Command="{Binding FileListControlCommands.ReloadCommand}" />
                 <KeyBinding Key="O" Command="{Binding FileListControlCommands.OpenDirectoryCommand}" />
+                <KeyBinding Key="U" Modifiers="Shift" Command="{Binding FileListControlCommands.MoveToParentDirectory}" />
 
                 <!-- 数字キーを受け取るコマンド -->
                 <KeyBinding Key="D0" Command="{Binding FileListControlCommands.SetRepeatCountCommand}"


### PR DESCRIPTION
- クラス追加 / コマンドを記述しておくためのモデルクラスを追加
- 機能追加 / FileList のカーソルを上げ下げするコマンドを実装
- 機能追加 / ファイルリストをリロードするコマンドを実装
- 仕様変更 / reload() を呼び出した際、SelectedIndex を初期化するよう変更
- 機能追加 / FileList のカーソルを最上段、最下段に移動するコマンドを実装
- 機能追加 / ウィンドウの任意の位置から ListView にフォーカスを移すコマンドを実装
- 機能追加 / コマンドを連続実行する際、任意の回数を入力できるよう実装
- 機能追加 / カーソルを上下させるコマンドを任意回数連続実行できるよう実装
- 機能追加 / 先頭にカーソルを移動するコマンドの機能を拡張
- 機能追加 / 選択したディレクトリを開くコマンドを実装
- 機能追加 / 一段上のディレクトリへ移動するコマンドを実装

close #6
