### PR TITLE
ListView を他のビューに切り替えられるようにする

### DIFF
--- a/WPFFiler/Dictionary.xaml
+++ b/WPFFiler/Dictionary.xaml
@@ -2,4 +2,72 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:WPFFiler">
     
+    <ListView ItemsSource="{Binding FileList.Files}"
+              SelectedIndex="{Binding FileList.SelectedIndex}"
+              x:Name="FileListView"
+              ScrollViewer.VerticalScrollBarVisibility="Visible"
+              x:Key="listViewResource"
+              >
+
+        <ListView.ItemContainerStyle>
+            <Style TargetType="ListViewItem">
+                <Setter Property="SnapsToDevicePixels"
+                        Value="true" />
+                <Setter Property="OverridesDefaultStyle"
+                        Value="true" />
+                <Setter Property="Template">
+
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ListViewItem">
+                            <Border x:Name="Border"
+                                      Padding="2"
+                                      SnapsToDevicePixels="true"
+                                      Background="Transparent">
+
+                                <VisualStateManager.VisualStateGroups>
+
+                                    <VisualStateGroup x:Name="SelectionStates">
+                                        <VisualState x:Name="Unselected" />
+                                        <VisualState x:Name="Selected">
+                                            <Storyboard>
+                                                <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                              Storyboard.TargetProperty="(Panel.Background).  (SolidColorBrush.Color)">
+                                                    <EasingColorKeyFrame KeyTime="0"
+                                                                         Value="LightBlue" />
+                                                </ColorAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="SelectedUnfocused">
+                                            <Storyboard>
+                                                <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
+                                                                          Storyboard.TargetProperty="(Panel.Background).  (SolidColorBrush.Color)">
+                                                    <EasingColorKeyFrame KeyTime="0"
+                                                                     Value="LightGray" />
+                                                </ColorAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+                                <GridViewRowPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+        </ListView.ItemContainerStyle>
+
+        <ListView.View>
+            <GridView>
+                <GridView.Columns>
+                    <GridViewColumn Header="name"
+                                    DisplayMemberBinding="{Binding Content.Name}"
+                                    />
+                </GridView.Columns>
+            </GridView>
+        </ListView.View>
+    </ListView>
+
 </ResourceDictionary>

--- a/WPFFiler/Dictionary.xaml
+++ b/WPFFiler/Dictionary.xaml
@@ -70,4 +70,20 @@
         </ListView.View>
     </ListView>
 
+    <ListBox x:Key="listBoxResource"
+             ItemsSource="{Binding FileList.Files}"
+             x:Shared="false"
+             SelectedIndex="{Binding FileList.SelectedIndex}"
+             >
+
+        <ListBox.ItemTemplate>
+            <DataTemplate>
+
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="{Binding Content.Name}"/>
+                </StackPanel>
+            </DataTemplate>
+        </ListBox.ItemTemplate>
+    </ListBox>
+
 </ResourceDictionary>

--- a/WPFFiler/Dictionary.xaml
+++ b/WPFFiler/Dictionary.xaml
@@ -1,0 +1,5 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:WPFFiler">
+    
+</ResourceDictionary>

--- a/WPFFiler/WPFFiler.csproj
+++ b/WPFFiler/WPFFiler.csproj
@@ -71,6 +71,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="Dictionary.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="views\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -7,8 +7,19 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+public enum ViewStyle {
+    ListView,
+    ListBox
+}
+
 namespace WPFFiler.models {
     public class FileList : BindableBase{
+
+        private ViewStyle viewStyle = ViewStyle.ListView;
+        public ViewStyle ViewStyle {
+            get => viewStyle;
+            set => SetProperty(ref viewStyle, value);
+        }
 
         private ObservableCollection<ExFile> files = new ObservableCollection<ExFile>();
         public ObservableCollection<ExFile> Files {

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -23,10 +23,11 @@
     <Window.InputBindings>
 
         <KeyBinding Key="Esc" Command="{Binding FileListControlCommands.FocusCommand}"
-                    CommandParameter="{Binding ElementName=FileListView}"
+                    CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                     />
         <KeyBinding Key="OemOpenBrackets" Modifiers="Ctrl" Command="{Binding FileListControlCommands.FocusCommand}"
-                    CommandParameter="{Binding ElementName=FileListView}"/>
+                    CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
+                    />
 
         <KeyBinding Key="K" Modifiers="Ctrl" Command="{Binding FileListControlCommands.FocusToURLBarCommandCommand}"
                     CommandParameter="{Binding ElementName=urlBar}"
@@ -55,32 +56,32 @@
               >
             <Grid.InputBindings>
                 <KeyBinding Key="J" Command="{Binding FileListControlCommands.DownCursorCommand}" 
-                            CommandParameter="{Binding ElementName=FileListView}"
+                            CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                             />
 
                 <KeyBinding Key="K" Command="{Binding FileListControlCommands.UpCursorCommand}" 
-                            CommandParameter="{Binding ElementName=FileListView}"
+                            CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                             />
 
                 <KeyBinding Key="D" Command="{Binding FileListControlCommands.PageDownCommand}" 
-                            CommandParameter="{Binding ElementName=FileListView}"
+                            CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                             />
 
                 <KeyBinding Key="U" Command="{Binding FileListControlCommands.PageUpCommand}" 
-                            CommandParameter="{Binding ElementName=FileListView}"
+                            CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                             />
 
                 <KeyBinding Key="G" Command="{Binding FileListControlCommands.MoveCursorToHeadCommand}"
-                            CommandParameter="{Binding ElementName=FileListView}"
+                            CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                             />
 
                 <KeyBinding Key="G" Modifiers="Shift" Command="{Binding FileListControlCommands.MoveCursorToEndCommand}"
-                            CommandParameter="{Binding ElementName=FileListView}"
+                            CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                             />
 
                 <KeyBinding Gesture="CTRL+R" Command="{Binding FileListControlCommands.ReloadCommand}" />
                 <KeyBinding Key="O" Command="{Binding FileListControlCommands.OpenDirectoryCommand}" 
-                            CommandParameter="{Binding ElementName=FileListView}"
+                            CommandParameter="{Binding ElementName=itemsControlContainer, Path=Content}"
                             />
 
                 <KeyBinding Key="U" Modifiers="Shift" Command="{Binding FileListControlCommands.MoveToParentDirectory}" />

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -12,6 +12,14 @@
         <dc:MainWindowViewModel/>
     </Window.DataContext>
 
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/Dictionary.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
     <Window.InputBindings>
 
         <KeyBinding Key="Esc" Command="{Binding FileListControlCommands.FocusCommand}"
@@ -102,73 +110,11 @@
                 
             </Grid.InputBindings>
 
-            <ListView ItemsSource="{Binding FileList.Files}"
-                      SelectedIndex="{Binding FileList.SelectedIndex}"
-                      x:Name="FileListView"
-                      ScrollViewer.VerticalScrollBarVisibility="Visible"
-                      >
 
-                <ListView.ItemContainerStyle>
-                    <Style TargetType="ListViewItem">
-                        <Setter Property="SnapsToDevicePixels"
-                                Value="true" />
-                        <Setter Property="OverridesDefaultStyle"
-                                Value="true" />
-                        <Setter Property="Template">
-
-                            <Setter.Value>
-                                <ControlTemplate TargetType="ListViewItem">
-                                    <Border x:Name="Border"
-                                              Padding="2"
-                                              SnapsToDevicePixels="true"
-                                              Background="Transparent">
-
-                                        <VisualStateManager.VisualStateGroups>
-
-                                            <VisualStateGroup x:Name="SelectionStates">
-                                                <VisualState x:Name="Unselected" />
-                                                <VisualState x:Name="Selected">
-                                                    <Storyboard>
-                                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                                                      Storyboard.TargetProperty="(Panel.Background).  (SolidColorBrush.Color)">
-                                                            <EasingColorKeyFrame KeyTime="0"
-                                                                                 Value="LightBlue" />
-                                                        </ColorAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-
-                                                <VisualState x:Name="SelectedUnfocused">
-                                                    <Storyboard>
-                                                        <ColorAnimationUsingKeyFrames Storyboard.TargetName="Border"
-                                                                                  Storyboard.TargetProperty="(Panel.Background).  (SolidColorBrush.Color)">
-                                                            <EasingColorKeyFrame KeyTime="0"
-                                                                             Value="LightGray" />
-                                                        </ColorAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-
-                                            </VisualStateGroup>
-                                        </VisualStateManager.VisualStateGroups>
-                                        <GridViewRowPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
-                                    </Border>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-
-                </ListView.ItemContainerStyle>
-
-                <ListView.View>
-                    <GridView>
-                        <GridView.Columns>
-                            <GridViewColumn Header="name"
-                                            DisplayMemberBinding="{Binding Content.Name}"
-                                            />
-                        </GridView.Columns>
-                    </GridView>
-                </ListView.View>
-            </ListView>
-
+            <ContentControl x:Name="itemsControlContainer"
+                            Content="{StaticResource listViewResource}">
+            </ContentControl>
+            
         </Grid>
     </Grid>
 </Window>

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -112,8 +112,27 @@
             </Grid.InputBindings>
 
 
-            <ContentControl x:Name="itemsControlContainer"
-                            Content="{StaticResource listViewResource}">
+            <ContentControl x:Name="itemsControlContainer">
+                <ContentControl.Style>
+                    <Style TargetType="ContentControl">
+                        <Style.Triggers>
+
+                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.FileList.ViewStyle}"
+                                         Value="ListView"
+                                         >
+                                <Setter Property="Content" Value="{StaticResource listViewResource}"/>
+                            </DataTrigger>
+
+                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.FileList.ViewStyle}"
+                                         Value="ListBox"
+                                         >
+                                <Setter Property="Content" Value="{StaticResource listBoxResource}"/>
+                            </DataTrigger>
+
+                        </Style.Triggers>
+                    </Style>
+                </ContentControl.Style>
+
             </ContentControl>
             
         </Grid>


### PR DESCRIPTION
- ItemsControl 部分のみを記述するためのリソースディクショナリを追加
- UI変更 / ListView をリソースディクショナリへ移動し、 cONTentControl を入れ替わりで設置
- 修正 / CommadParameter の参照先を ContentControl.Content へ変更
- UI変更 / ResourceDictionary に新規 ListBox を追加
- 機能追加 / FileListモデルに、ListView の見た目の状態を表す列挙型を追加
- 機能追加 / ContentControl.Content を DataTrigger によってセットするよう変更

close #17
