### PR TITLE
複製画面モードを実装する

### DIFF
--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -15,10 +15,16 @@ public enum ViewStyle {
 namespace WPFFiler.models {
     public class FileList : BindableBase{
 
-        private ViewStyle viewStyle = ViewStyle.ListView;
-        public ViewStyle ViewStyle {
-            get => viewStyle;
-            set => SetProperty(ref viewStyle, value);
+        private ViewStyle leftViewStyle = ViewStyle.ListView;
+        public ViewStyle LeftViewStyle {
+            get => leftViewStyle;
+            set => SetProperty(ref leftViewStyle, value);
+        }
+
+        private ViewStyle rightViewStyle = ViewStyle.ListView;
+        public ViewStyle RightViewStyle {
+            get => rightViewStyle;
+            set => SetProperty(ref rightViewStyle, value);
         }
 
         private ObservableCollection<ExFile> files = new ObservableCollection<ExFile>();

--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -27,6 +27,8 @@ namespace WPFFiler.models {
             set => SetProperty(ref rightViewStyle, value);
         }
 
+        public bool BothViewBinding { get; set; } = false;
+
         private ObservableCollection<ExFile> files = new ObservableCollection<ExFile>();
         public ObservableCollection<ExFile> Files {
             get => files;

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -498,6 +498,46 @@ namespace WPFFiler.models {
         }
 
         /// <summary>
+        /// ウィンドウに配置されている２つの ListView,ListBox を取得します。
+        /// このメソッドは実装の関係で、Grid.ContentControl.Content == ListView という配置になっていない場合は空のリストを返します。
+        /// View の仕様が変化した場合は完全に動かなくなる可能性があるので注意
+        /// </summary>
+        /// <returns></returns>
+        private List<ListBox> getListBoxes() {
+            if (Keyboard.FocusedElement == null) {
+                return null;
+            }
+
+            var list = new List<ListBox>();
+
+            var obj = (System.Windows.DependencyObject)Keyboard.FocusedElement;
+            while(!(obj is Grid)) {
+                obj = System.Windows.Media.VisualTreeHelper.GetParent(obj);
+
+                if(obj == null) {
+                    break;
+                }
+            }
+
+            if(obj != null) {
+                var cnt = System.Windows.Media.VisualTreeHelper.GetChildrenCount((Grid)obj);
+                for(int i = 0; i < cnt; i++) {
+                    ContentControl l = System.Windows.Media.VisualTreeHelper.GetChild(obj, i) as ContentControl;
+                    if(l != null) {
+                        list.Add((ListBox)l.Content);
+                    }
+
+                    // 配置されている、ListViewを含むContentControl は２つであるため、要素数が２になった時点で終了で良い。
+                    if(list.Count == 2) {
+                        break;
+                    }
+                }
+            }
+
+            return list;
+        }
+
+        /// <summary>
         /// ListView から、それに紐付いている FileList モデルを取得します。
         /// </summary>
         /// <param name="lv"></param>

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -31,10 +31,12 @@ namespace WPFFiler.models {
             get => moveCursorToEndCommand ?? (moveCursorToEndCommand = new DelegateCommand(
                 () => {
                     var lv = getFocusingListView();
+                    var fl = getFileListFromListView(lv);
+                    List<ListBox> lbs = (fl.BothViewBinding) ? getListBoxes() : new List<ListBox>(new ListBox[] { lv });
                     if(lv != null) {
                         FileList currentFileList = getFileListFromListView(lv);
                         currentFileList.SelectedIndex = currentFileList.Files.Count - 1;
-                        lv.ScrollIntoView(lv.SelectedItem);
+                        lbs.ForEach((l) => l.ScrollIntoView(l.SelectedItem));
                     }
                 }
             ));
@@ -47,14 +49,15 @@ namespace WPFFiler.models {
                     var lv = getFocusingListView();
                     if(lv != null) {
                         FileList fl = getFileListFromListView(lv);
+                        List<ListBox> lbs = (fl.BothViewBinding) ? getListBoxes() : new List<ListBox>(new ListBox[] { lv });
                         if(repeatCount == 0) {
                             fl.SelectedIndex = 0;
-                            lv.ScrollIntoView(lv.SelectedItem);
+                            lbs.ForEach((l) => l.ScrollIntoView(l.SelectedItem));
                             
                         }
                         else {
                             fl.SelectedIndex = repeatCount;
-                            lv.ScrollIntoView(lv.SelectedItem);
+                            lbs.ForEach((l) => l.ScrollIntoView(l.SelectedItem));
                             repeatCount = 0;
                         }
                     }
@@ -68,11 +71,13 @@ namespace WPFFiler.models {
                 () => {
                     var lv = getFocusingListView();
                     if(lv != null) {
+
                         var fl = getFileListFromListView(lv);
+                        List<ListBox> lbs = (fl.BothViewBinding) ? getListBoxes() : new List<ListBox>(new ListBox[] { lv });
 
                         var action = new Action(() => {
                             fl.SelectedIndex++;
-                            lv.ScrollIntoView(lv.SelectedItem);
+                            lbs.ForEach((l) => l.ScrollIntoView(l.SelectedItem));
                         });
 
                         if(repeatCount == 0) {
@@ -93,9 +98,10 @@ namespace WPFFiler.models {
                     var lv = getFocusingListView();
                     if(lv != null) {
                         var fl = getFileListFromListView(lv);
+                        List<ListBox> lbs = (fl.BothViewBinding) ? getListBoxes() : new List<ListBox>(new ListBox[] { lv });
                         var action = new Action(() => {
                             fl.SelectedIndex--;
-                            lv.ScrollIntoView(lv.SelectedItem);
+                            lbs.ForEach((l) => l.ScrollIntoView(l.SelectedItem));
                         });
 
                         if(repeatCount == 0) {
@@ -116,7 +122,7 @@ namespace WPFFiler.models {
                     var lv = getFocusingListView();
                     if(lv != null) {
                         var fl = getFileListFromListView(lv);
-
+                        List<ListBox> lbs = (fl.BothViewBinding) ? getListBoxes() : new List<ListBox>(new ListBox[] { lv });
                         Action action = new Action(() => {
                             if(fl.Files.Count > 0) {
                                 lv.UpdateLayout();
@@ -125,7 +131,7 @@ namespace WPFFiler.models {
                                 // -1 ではなく -2 なのでは、listBox.ActualHeight に header も含まれていると思われるためその分 -1
                                 int itemDisplayCapacity = (int)Math.Floor(lv.ActualHeight / lbItem.ActualHeight) - 2;
                                 fl.SelectedIndex -= itemDisplayCapacity;
-                                lv.ScrollIntoView(lv.SelectedItem);
+                                lbs.ForEach((l) => l.ScrollIntoView(l.SelectedItem));
                             }
                         });
 
@@ -147,6 +153,7 @@ namespace WPFFiler.models {
                     var lv = getFocusingListView();
                     if(lv != null) {
                         var fl = getFileListFromListView(lv);
+                        List<ListBox> lbs = (fl.BothViewBinding) ? getListBoxes() : new List<ListBox>(new ListBox[] { lv });
                         Action action = new Action(() => {
                             if(fl.Files.Count > 0) {
                                 lv.UpdateLayout();
@@ -156,6 +163,7 @@ namespace WPFFiler.models {
                                 int itemDisplayCapacity = (int)Math.Floor(lv.ActualHeight / lbItem.ActualHeight) - 2;
                                 fl.SelectedIndex += itemDisplayCapacity;
                                 lv.ScrollIntoView(lv.SelectedItem);
+                                lbs.ForEach((l) => l.ScrollIntoView(l.SelectedItem));
                             }
                         });
 

--- a/WPFFiler/models/FileListControlCommands.cs
+++ b/WPFFiler/models/FileListControlCommands.cs
@@ -402,24 +402,31 @@ namespace WPFFiler.models {
             ));
         }
 
-        private DelegateCommand<ListBox> changeToListBoxStyleCommand;
-        public DelegateCommand<ListBox> ChangeToListBoxStyleCommand {
-            get => changeToListBoxStyleCommand ?? (changeToListBoxStyleCommand = new DelegateCommand<ListBox>(
-                (ListBox lb) => {
-                    var listBox = lb as ListBox;
-                    var currentFL = getFileListFromListView(listBox);
-                    currentFL.ViewStyle = ViewStyle.ListBox;
-                }
+        private DelegateCommand<ListBox> changeLeftViewStyleToListViewStyleCommand;
+        public DelegateCommand<ListBox> ChangeLeftViewStyleToListViewStyleCommand {
+            get => changeLeftViewStyleToListViewStyleCommand ?? (changeLeftViewStyleToListViewStyleCommand = new DelegateCommand<ListBox>(
+                (lb) => getFileListFromListView(lb).LeftViewStyle = ViewStyle.ListView
             ));
         }
 
-        private DelegateCommand<ListBox> changeToListViewStyleCommand;
-        public DelegateCommand<ListBox> ChangeToListViewStyleCommand {
-            get => changeToListViewStyleCommand ?? (changeToListViewStyleCommand = new DelegateCommand<ListBox>(
-                (ListBox lb) => {
-                    var fl = getFileListFromListView(lb);
-                    fl.ViewStyle = ViewStyle.ListView;
-                }
+        private DelegateCommand<ListBox> changeLeftViewStyleToListBoxStyleCommand;
+        public DelegateCommand<ListBox> ChangeLeftViewStyleToListBoxStyleCommand {
+            get => changeLeftViewStyleToListBoxStyleCommand ?? (changeLeftViewStyleToListBoxStyleCommand = new DelegateCommand<ListBox>(
+                (lb) => getFileListFromListView(lb).LeftViewStyle = ViewStyle.ListBox
+            ));
+        }
+  
+        private DelegateCommand<ListBox> changeRightViewStyleToListViewStyleCommand;
+        public DelegateCommand<ListBox> ChangeRightViewStyleToListViewStyleCommand {
+            get => changeRightViewStyleToListViewStyleCommand ?? (changeRightViewStyleToListViewStyleCommand = new DelegateCommand<ListBox>(
+                (lb) => getFileListFromListView(lb).RightViewStyle = ViewStyle.ListView
+            ));
+        }
+
+        private DelegateCommand<ListBox> changeRightViewStyleToListBoxStyleCommand;
+        public DelegateCommand<ListBox> ChangeRightViewStyleToListBoxStyleCommand {
+            get => changeRightViewStyleToListBoxStyleCommand ?? (changeRightViewStyleToListBoxStyleCommand = new DelegateCommand<ListBox>(
+                (lb) => getFileListFromListView(lb).RightViewStyle = ViewStyle.ListBox
             ));
         }
 

--- a/WPFFiler/viewModels/MainWindowViewModel.cs
+++ b/WPFFiler/viewModels/MainWindowViewModel.cs
@@ -49,6 +49,7 @@ namespace WPFFiler.ViewModels {
                         mainFileListStorage = FileList;
                         subFileListStorage = SubFileList;
                         SubFileList = FileList;
+                        FileList.BothViewBinding = true;
                     }
                 }
             ));
@@ -60,7 +61,10 @@ namespace WPFFiler.ViewModels {
                 () => {
                     if(mainFileListStorage != null || subFileListStorage != null) {
                         FileList = mainFileListStorage;
+                        FileList.BothViewBinding = false;
                         SubFileList = subFileListStorage;
+                        SubFileList.BothViewBinding = false;
+
                         mainFileListStorage = null;
                         subFileListStorage = null;
                     }

--- a/WPFFiler/viewModels/MainWindowViewModel.cs
+++ b/WPFFiler/viewModels/MainWindowViewModel.cs
@@ -8,18 +8,25 @@ using System.Text;
 using System.Threading.Tasks;
 using WPFFiler.models;
 using Prism.Services.Dialogs;
+using Prism.Commands;
 
 namespace WPFFiler.ViewModels {
     class MainWindowViewModel : BindableBase {
+        private FileList fileList = new FileList(@"C:\");
         public FileList FileList {
-            get;
-            private set;
-        } = new FileList(@"C:\");
+            get => fileList;
+            private set => SetProperty(ref fileList, value);
+        }
 
+        private FileList mainFileListStorage = null;
+
+        private FileList subFileList = new FileList(@"C:\");
         public FileList SubFileList {
-            get;
-            private set;
-        } = new FileList(@"C:\");
+            get => subFileList;
+            private set => SetProperty(ref subFileList, value);
+        }
+
+        private FileList subFileListStorage = null;
 
         private FileListControlCommands fileListControlCommands;
         public FileListControlCommands FileListControlCommands {
@@ -34,5 +41,31 @@ namespace WPFFiler.ViewModels {
             FileListControlCommands = new FileListControlCommands(dialogService, FileList, SubFileList);
         }
 
+        private DelegateCommand changeToMirrorModeCommand;
+        public DelegateCommand ChangeToMirrorModeCommand {
+            get => changeToMirrorModeCommand ?? (changeToMirrorModeCommand = new DelegateCommand(
+                () => {
+                    if(mainFileListStorage == null && subFileListStorage == null) {
+                        mainFileListStorage = FileList;
+                        subFileListStorage = SubFileList;
+                        SubFileList = FileList;
+                    }
+                }
+            ));
+        }
+
+        private DelegateCommand changeToTwoScreenModeCommand;
+        public DelegateCommand ChangeToTwoScreenModeCommand {
+            get => changeToTwoScreenModeCommand ?? (changeToTwoScreenModeCommand = new DelegateCommand(
+                () => {
+                    if(mainFileListStorage != null || subFileListStorage != null) {
+                        FileList = mainFileListStorage;
+                        SubFileList = subFileListStorage;
+                        mainFileListStorage = null;
+                        subFileListStorage = null;
+                    }
+                }
+            ));
+        }
     }
 }

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -61,8 +61,12 @@
             </MenuItem>
 
             <MenuItem Header="モード(_M)">
-                <MenuItem Header="２画面ファイラ"/>
-                <MenuItem Header="複製画面"/>
+                <MenuItem Header="２画面ファイラ"
+                          Command="{Binding ChangeToTwoScreenModeCommand}"
+                          />
+                <MenuItem Header="複製画面"
+                          Command="{Binding ChangeToMirrorModeCommand}"
+                          />
             </MenuItem>
 
             <MenuItem Header="左画面(_L)">

--- a/WPFFiler/views/MainWindow.xaml
+++ b/WPFFiler/views/MainWindow.xaml
@@ -71,22 +71,22 @@
 
             <MenuItem Header="左画面(_L)">
                 <MenuItem Header="リストビュー(_L)"
-                          Command="{Binding FileListControlCommands.ChangeToListViewStyleCommand}"
+                          Command="{Binding FileListControlCommands.ChangeLeftViewStyleToListViewStyleCommand}"
                           CommandParameter="{Binding ElementName=itemsControlContainer,Path=Content}"
                           />
                 <MenuItem Header="リストボックス(_B)"
-                          Command="{Binding FileListControlCommands.ChangeToListBoxStyleCommand}"
+                          Command="{Binding FileListControlCommands.ChangeLeftViewStyleToListBoxStyleCommand}"
                           CommandParameter="{Binding ElementName=itemsControlContainer,Path=Content}"
                           />
             </MenuItem>
 
             <MenuItem Header="右画面(_R)">
                 <MenuItem Header="リストビュー(_L)"
-                          Command="{Binding FileListControlCommands.ChangeToListViewStyleCommand}"
+                          Command="{Binding FileListControlCommands.ChangeRightViewStyleToListViewStyleCommand}"
                           CommandParameter="{Binding ElementName=subItemsContentContorol,Path=Content}"
                           />
                 <MenuItem Header="リストボックス(_B)"
-                          Command="{Binding FileListControlCommands.ChangeToListBoxStyleCommand}"
+                          Command="{Binding FileListControlCommands.ChangeRightViewStyleToListBoxStyleCommand}"
                           CommandParameter="{Binding ElementName=subItemsContentContorol,Path=Content}"
                           />
             </MenuItem>
@@ -188,7 +188,7 @@
                     <Style TargetType="ContentControl">
                         <Style.Triggers>
 
-                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.FileList.ViewStyle}"
+                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.FileList.LeftViewStyle}"
                                          Value="ListView"
                                          >
 
@@ -224,7 +224,7 @@
                                 </Setter>
                             </DataTrigger>
 
-                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.FileList.ViewStyle}"
+                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.FileList.LeftViewStyle}"
                                          Value="ListBox"
                                          >
                                 <Setter Property="Content">
@@ -277,7 +277,7 @@
                     <Style TargetType="ContentControl">
                         <Style.Triggers>
 
-                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.SubFileList.ViewStyle}"
+                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.SubFileList.RightViewStyle}"
                                          Value="ListView"
                                          >
 
@@ -312,7 +312,7 @@
                                 </Setter>
                             </DataTrigger>
 
-                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.SubFileList.ViewStyle}"
+                            <DataTrigger Binding= "{Binding RelativeSource={RelativeSource AncestorType=Window}, Path=DataContext.SubFileList.RightViewStyle}"
                                          Value="ListBox"
                                          >
                                 <Setter Property="Content">


### PR DESCRIPTION
- 機能追加 / 複製画面モードを実装
- 機能追加 / 複製画面モード中でも、左右別々のビュースタイルを設定できるよう実装
- プロパティ追加 / FileList に、複数のビューのソースとしてバインドされているかを示すプロパティを追加
- 機能追加 / FileListControlCommands に、２つのListViewを取得するメソッドを追加
- 修正 / 複製画面モード時、左右のビューがカーソルの移動に追従するよう実装

close #55
