### PR TITLE
バグ修正 / 特定の状況でディレクトリの読み込みに異常に時間がかかる件を修正

### DIFF
--- a/WPFFiler/models/FileList.cs
+++ b/WPFFiler/models/FileList.cs
@@ -29,8 +29,8 @@ namespace WPFFiler.models {
 
         public bool BothViewBinding { get; set; } = false;
 
-        private ObservableCollection<ExFile> files = new ObservableCollection<ExFile>();
-        public ObservableCollection<ExFile> Files {
+        private List<ExFile> files = new List<ExFile>();
+        public List<ExFile> Files {
             get => files;
             set => SetProperty(ref files, value);
         }
@@ -73,20 +73,16 @@ namespace WPFFiler.models {
             string[] paths = Directory.GetFiles(CurrentDirectoryPath);
             string[] directoryPaths = Directory.GetDirectories(CurrentDirectoryPath);
 
-            Files.Clear();
-            List<ExFile> tempFiles = new List<ExFile>();
+            List<ExFile> allFiles = new List<ExFile>();
             foreach(string p in paths) {
-                tempFiles.Add(new ExFile(p));
+                allFiles.Add(new ExFile(p));
             }
 
-            List<ExFile> tempDirectories = new List<ExFile>();
             foreach(string dp in directoryPaths) {
-                tempDirectories.Add(new ExFile(dp));
+                allFiles.Add(new ExFile(dp));
             }
 
-            Files.AddRange(tempFiles);
-            files.AddRange(tempDirectories);
-
+            Files = allFiles;
             SelectedIndex = 0;
         }
 


### PR DESCRIPTION
時間がかかる原因 : 推測になるが、FileList.Files.get にデバッグ出力をしかけてみたところ、フォルダに入っているファイル数分のアクセスが発生していることがわかった
これは、ObservableCollection<T> を使用しているからであると思われる。
対策 : アプリの要件的には、最終的に全ファイルのリストを得られて表示できるのであれば問題なく、更新通知も明示的に飛ばすことも可能なので、これを List<T> 型へ変更する。これによりパフォーマンスを維持できるようになった。

close #61
